### PR TITLE
Add support for badminton, squash, padel, and pickleball

### DIFF
--- a/backend/internal/service/club_service.go
+++ b/backend/internal/service/club_service.go
@@ -22,6 +22,10 @@ type ClubService struct {
 var supportedClubSports = map[pb.Sport]struct{}{
 	pb.Sport_SPORT_TABLE_TENNIS: {},
 	pb.Sport_SPORT_TENNIS:       {},
+	pb.Sport_SPORT_PADEL:        {},
+	pb.Sport_SPORT_BADMINTON:    {},
+	pb.Sport_SPORT_SQUASH:       {},
+	pb.Sport_SPORT_PICKLEBALL:   {},
 }
 
 func (s *ClubService) CreateClub(ctx context.Context, in *pb.CreateClubRequest) (*pb.CreateClubResponse, error) {

--- a/backend/internal/service/match_service.go
+++ b/backend/internal/service/match_service.go
@@ -153,9 +153,14 @@ func (s *MatchService) ReportMatchV2(ctx context.Context, in *pb.ReportMatchV2Re
 	var scoreA, scoreB int32
 
 	switch series.Sport {
-	case int32(pb.Sport_SPORT_TABLE_TENNIS), int32(pb.Sport_SPORT_TENNIS):
-		// For table tennis and tennis, use TABLE_TENNIS_SETS scoring
-		// Both sports use the same best-of-N sets format
+	case int32(pb.Sport_SPORT_TABLE_TENNIS),
+		int32(pb.Sport_SPORT_TENNIS),
+		int32(pb.Sport_SPORT_PADEL),
+		int32(pb.Sport_SPORT_BADMINTON),
+		int32(pb.Sport_SPORT_SQUASH),
+		int32(pb.Sport_SPORT_PICKLEBALL):
+		// All racket/paddle sports use TABLE_TENNIS_SETS scoring
+		// They share the same best-of-N sets format
 		ttResult := in.GetResult().GetTableTennis()
 		if ttResult == nil {
 			return nil, status.Error(codes.InvalidArgument, "VALIDATION_TABLE_TENNIS_RESULT_REQUIRED")

--- a/backend/openapi/klubbspel.swagger.json
+++ b/backend/openapi/klubbspel.swagger.json
@@ -1130,7 +1130,7 @@
           },
           {
             "name": "sportFilter",
-            "description": "Optional filter by sport.\n\n - SPORT_UNSPECIFIED: Default value, should not be used explicitly.\n - SPORT_TABLE_TENNIS: Classic ping pong / table tennis.\n - SPORT_TENNIS: Lawn/indoor tennis.\n - SPORT_PADEL: Padel tennis.",
+            "description": "Optional filter by sport.\n\n - SPORT_UNSPECIFIED: Default value, should not be used explicitly.\n - SPORT_TABLE_TENNIS: Classic ping pong / table tennis.\n - SPORT_TENNIS: Lawn/indoor tennis.\n - SPORT_PADEL: Padel tennis.\n - SPORT_BADMINTON: Badminton.\n - SPORT_SQUASH: Squash.\n - SPORT_PICKLEBALL: Pickleball.\n - SPORT_RACQUETBALL: Racquetball.\n - SPORT_BEACH_TENNIS: Beach tennis.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -1138,7 +1138,12 @@
               "SPORT_UNSPECIFIED",
               "SPORT_TABLE_TENNIS",
               "SPORT_TENNIS",
-              "SPORT_PADEL"
+              "SPORT_PADEL",
+              "SPORT_BADMINTON",
+              "SPORT_SQUASH",
+              "SPORT_PICKLEBALL",
+              "SPORT_RACQUETBALL",
+              "SPORT_BEACH_TENNIS"
             ],
             "default": "SPORT_UNSPECIFIED"
           },
@@ -2594,10 +2599,15 @@
         "SPORT_UNSPECIFIED",
         "SPORT_TABLE_TENNIS",
         "SPORT_TENNIS",
-        "SPORT_PADEL"
+        "SPORT_PADEL",
+        "SPORT_BADMINTON",
+        "SPORT_SQUASH",
+        "SPORT_PICKLEBALL",
+        "SPORT_RACQUETBALL",
+        "SPORT_BEACH_TENNIS"
       ],
       "default": "SPORT_UNSPECIFIED",
-      "description": "Sport enumerates racket/paddle sports supported by the platform.\nTable tennis is currently the only fully supported sport but we define\nadditional values so that the API is future proof.\n\n - SPORT_UNSPECIFIED: Default value, should not be used explicitly.\n - SPORT_TABLE_TENNIS: Classic ping pong / table tennis.\n - SPORT_TENNIS: Lawn/indoor tennis.\n - SPORT_PADEL: Padel tennis."
+      "description": "Sport enumerates racket/paddle sports supported by the platform.\nTable tennis is currently the only fully supported sport but we define\nadditional values so that the API is future proof.\n\n - SPORT_UNSPECIFIED: Default value, should not be used explicitly.\n - SPORT_TABLE_TENNIS: Classic ping pong / table tennis.\n - SPORT_TENNIS: Lawn/indoor tennis.\n - SPORT_PADEL: Padel tennis.\n - SPORT_BADMINTON: Badminton.\n - SPORT_SQUASH: Squash.\n - SPORT_PICKLEBALL: Pickleball.\n - SPORT_RACQUETBALL: Racquetball.\n - SPORT_BEACH_TENNIS: Beach tennis."
     },
     "v1StrokeCardResult": {
       "type": "object",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -372,6 +372,11 @@
     "table_tennis": "Table tennis",
     "tennis": "Tennis",
     "padel": "Padel",
+    "badminton": "Badminton",
+    "squash": "Squash",
+    "pickleball": "Pickleball",
+    "racquetball": "Racquetball",
+    "beach_tennis": "Beach tennis",
     "unknown": "Unknown sport"
   }
 }

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -372,6 +372,11 @@
     "table_tennis": "Bordtennis",
     "tennis": "Tennis",
     "padel": "Padel",
+    "badminton": "Badminton",
+    "squash": "Squash",
+    "pickleball": "Pickleball",
+    "racquetball": "Racquetball",
+    "beach_tennis": "Beachtennis",
     "unknown": "Okänd sport"
   }
 }

--- a/frontend/src/lib/sports.ts
+++ b/frontend/src/lib/sports.ts
@@ -1,9 +1,16 @@
 import type { Sport, SeriesFormat } from '@/types/api'
 import type { LucideIcon } from 'lucide-react'
-import { Circle, CircleDot } from 'lucide-react'
+import { Circle, CircleDot, Swords, Wind, Zap } from 'lucide-react'
 
 export const DEFAULT_SPORT: Sport = 'SPORT_TABLE_TENNIS'
-export const SUPPORTED_SPORTS: Sport[] = [DEFAULT_SPORT, 'SPORT_TENNIS']
+export const SUPPORTED_SPORTS: Sport[] = [
+  DEFAULT_SPORT,
+  'SPORT_TENNIS',
+  'SPORT_PADEL',
+  'SPORT_BADMINTON',
+  'SPORT_SQUASH',
+  'SPORT_PICKLEBALL'
+]
 
 export const DEFAULT_SERIES_FORMAT: SeriesFormat = 'SERIES_FORMAT_OPEN_PLAY'
 export const SUPPORTED_SERIES_FORMATS: SeriesFormat[] = [DEFAULT_SERIES_FORMAT]
@@ -18,6 +25,14 @@ export function sportTranslationKey(sport: Sport): string {
       return 'sports.table_tennis'
     case 'SPORT_TENNIS':
       return 'sports.tennis'
+    case 'SPORT_PADEL':
+      return 'sports.padel'
+    case 'SPORT_BADMINTON':
+      return 'sports.badminton'
+    case 'SPORT_SQUASH':
+      return 'sports.squash'
+    case 'SPORT_PICKLEBALL':
+      return 'sports.pickleball'
     default:
       return 'sports.unknown'
   }
@@ -29,6 +44,14 @@ export function sportIconComponent(sport: Sport): LucideIcon {
       return CircleDot  // Represents ping pong ball
     case 'SPORT_TENNIS':
       return Circle     // Represents tennis ball
+    case 'SPORT_PADEL':
+      return Swords     // Crossed paddles/rackets
+    case 'SPORT_BADMINTON':
+      return Wind       // Shuttlecock/speed
+    case 'SPORT_SQUASH':
+      return Zap        // Fast-paced
+    case 'SPORT_PICKLEBALL':
+      return CircleDot  // Similar to table tennis
     default:
       return Circle
   }

--- a/proto/klubbspel/v1/common.proto
+++ b/proto/klubbspel/v1/common.proto
@@ -21,6 +21,16 @@ enum Sport {
   SPORT_TENNIS = 2;
   // Padel tennis.
   SPORT_PADEL = 3;
+  // Badminton.
+  SPORT_BADMINTON = 4;
+  // Squash.
+  SPORT_SQUASH = 5;
+  // Pickleball.
+  SPORT_PICKLEBALL = 6;
+  // Racquetball.
+  SPORT_RACQUETBALL = 7;
+  // Beach tennis.
+  SPORT_BEACH_TENNIS = 8;
 }
 
 // ScoringProfile defines how match results are scored and validated


### PR DESCRIPTION
## Summary
- extend the shared sport enum and generated OpenAPI schema with additional racket and paddle options
- allow the backend match and club services to accept the new best-of-N set sports
- surface the new sports in the frontend with icons and translations in Swedish and English

## Testing
- `make lint`
- `make be.build`
- `make fe.build`
- `make test`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68dfa00e547483248118a0a42692337f